### PR TITLE
feat: add HTTP adapter for MuJoCo bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+
+## Adapter (HTTP → WS Bridge)
+
+Run both the WebSocket bridge and the HTTP adapter:
+```bash
+./run_all.sh
+
+Send a control command (degrees + steps):
+curl -s -X POST http://127.0.0.1:8088/control \
+  -H 'Content-Type: application/json' \
+  -d '{"j1": 25, "j2": -35, "steps": 250}' | jq .
+
+Expected response:
+{
+  "ok": true,
+  "result": {
+    "ok": true,
+    "obs": {
+      "qpos": [...],
+      "qvel": [...],
+      "time": ...
+    }
+  }
+}
+
+
+## Adapter (HTTP → WS Bridge)
+
+Run both the WebSocket bridge and the HTTP adapter:
+```bash
+./run_all.sh
+
+Send a control command (degrees + steps):
+curl -s -X POST http://127.0.0.1:8088/control \
+  -H 'Content-Type: application/json' \
+  -d '{"j1": 25, "j2": -35, "steps": 250}' | jq .
+
+Expected response:
+{
+  "ok": true,
+  "result": {
+    "ok": true,
+    "obs": {
+      "qpos": [...],
+      "qvel": [...],
+      "time": ...
+    }
+  }
+}
+

--- a/om1_bridge/adapter.py
+++ b/om1_bridge/adapter.py
@@ -1,0 +1,45 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json, os
+import asyncio, websockets
+
+WS_URI = f"ws://{os.getenv('OM1_BRIDGE_HOST','127.0.0.1')}:{int(os.getenv('OM1_BRIDGE_PORT','8765'))}"
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code, payload):
+        self.send_response(code)
+        self.send_header("Content-Type","application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode())
+
+    def do_POST(self):
+        if self.path != "/control":
+            return self._send(404, {"ok": False, "error": "not found"})
+        try:
+            ln = int(self.headers.get("Content-Length","0"))
+            body = self.rfile.read(ln)
+            data = json.loads(body or "{}")
+
+            j1 = float(data.get("j1", 0))
+            j2 = float(data.get("j2", 0))
+            steps = int(data.get("steps", 200))
+
+            async def go():
+                async with websockets.connect(WS_URI) as ws:
+                    await ws.send(json.dumps({"op":"reset"})); await ws.recv()
+                    await ws.send(json.dumps({"op":"set","target":{"j1":j1,"j2":j2}})); await ws.recv()
+                    await ws.send(json.dumps({"op":"step","n":steps}))
+                    return json.loads(await ws.recv())
+
+            obs = asyncio.run(go())
+            return self._send(200, {"ok": True, "result": obs})
+
+        except Exception as e:
+            return self._send(400, {"ok": False, "error": str(e)})
+
+def run_http(host="0.0.0.0", port=int(os.getenv("OM1_HTTP_PORT","8088"))):
+    httpd = HTTPServer((host, port), Handler)
+    print(f"[adapter] HTTP listening on http://{host}:{port}  -> WS {WS_URI}")
+    httpd.serve_forever()
+
+if __name__ == "__main__":
+    run_http()

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source .venv/bin/activate
+
+python -m om1_bridge.bridge &
+BRIDGE_PID=$!
+
+cleanup() {
+  kill "$BRIDGE_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+python -m om1_bridge.adapter


### PR DESCRIPTION
Adds a minimal HTTP adapter exposing a /control endpoint and forwarding to the WebSocket bridge.

- New: om1_bridge/adapter.py
- New: run_all.sh (runs bridge + adapter together)
- Docs: README usage instructions

Example:
./run_all.sh
curl -s -X POST http://127.0.0.1:8088/control -H 'Content-Type: application/json' -d '{"j1":25,"j2":-35,"steps":250}' | jq .
